### PR TITLE
feat: add reusable svg logo component

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,13 +1,14 @@
 import { Button } from "@/components/ui/button";
 import { Search, Menu, User, Building2 } from "lucide-react";
 import { useState } from "react";
+import Logo from "@/components/Logo";
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   return <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container flex h-16 items-center justify-between px-4">
         {/* Logo */}
         <div className="flex items-center space-x-3">
-          <img src="/src/assets/tradestone-logo.png" alt="TradeStone Logo" className="h-10 w-auto" />
+          <Logo className="h-10 w-auto" />
           <span className="text-xl font-bold text-foreground">TradeStone</span>
         </div>
 

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,0 +1,47 @@
+import { cn } from "@/lib/utils";
+
+interface LogoProps {
+  className?: string;
+}
+
+const Logo = ({ className }: LogoProps) => (
+  <svg
+    viewBox="0 0 120 140"
+    xmlns="http://www.w3.org/2000/svg"
+    role="img"
+    aria-label="TradeStone logo"
+    className={cn("h-10 w-auto", className)}
+  >
+    <title>TradeStone</title>
+    <defs>
+      <linearGradient id="logo-flame" x1="50%" x2="50%" y1="0%" y2="100%">
+        <stop offset="0%" stopColor="#FDB654" />
+        <stop offset="100%" stopColor="#FF6B1A" />
+      </linearGradient>
+      <linearGradient id="logo-eye" x1="30%" x2="70%" y1="30%" y2="70%">
+        <stop offset="0%" stopColor="#FFD27D" />
+        <stop offset="100%" stopColor="#FF7A1F" />
+      </linearGradient>
+      <filter id="logo-shadow" x="-20%" y="-20%" width="140%" height="150%" colorInterpolationFilters="sRGB">
+        <feDropShadow dx="0" dy="3" stdDeviation="4" floodColor="#0F172A" floodOpacity="0.25" />
+      </filter>
+    </defs>
+
+    <g filter="url(#logo-shadow)">
+      <rect x="24" y="32" width="72" height="56" rx="10" fill="#1B2538" />
+      <rect x="44" y="16" width="32" height="18" rx="6" fill="#1B2538" />
+      <rect x="8" y="40" width="20" height="40" rx="8" fill="#1B2538" />
+      <rect x="92" y="40" width="20" height="40" rx="8" fill="#1B2538" />
+
+      <circle cx="60" cy="60" r="22" fill="white" opacity="0.9" />
+      <circle cx="60" cy="60" r="16" fill="url(#logo-eye)" />
+      <circle cx="66" cy="54" r="4" fill="white" opacity="0.85" />
+
+      <rect x="52" y="88" width="16" height="26" rx="6" fill="#1B2538" />
+      <path d="M60 114 L46 138 H74 Z" fill="url(#logo-flame)" />
+      <path d="M52 99 L60 107 L68 99" stroke="#FF8B37" strokeWidth="4" strokeLinecap="round" strokeLinejoin="round" />
+    </g>
+  </svg>
+);
+
+export default Logo;

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
   return (

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,7 @@
 import Header from "@/components/Header";
 import HeroSection from "@/components/HeroSection";
 import ContractorDirectory from "@/components/ContractorDirectory";
+import Logo from "@/components/Logo";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -225,7 +226,7 @@ const Index = () => {
             <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
               <div>
                 <div className="flex items-center space-x-2 mb-4">
-                  <img src="/src/assets/tradestone-logo.png" alt="TradeStone Logo" className="h-8 w-auto" />
+                  <Logo className="h-8 w-auto" />
                   <span className="text-xl font-bold">TradeStone</span>
                 </div>
                 <p className="text-muted-foreground text-sm">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -87,5 +88,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add an inline SVG TradeStone logo component to mirror the updated branding
- replace image references in the header and footer with the new logo component
- clean up lint issues by preferring type aliases and ESM tailwind plugin import

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d06276f854832bb81ea3525b74e03e