### PR TITLE
Fix logo asset references

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,15 +1,15 @@
 import { Button } from "@/components/ui/button";
 import { Search, Menu, User, Building2 } from "lucide-react";
 import { useState } from "react";
-import tradeStoneLogoCorrect from "@/assets/tradestone-logo-correct.png";
+import tradestoneLogo from "@/assets/tradestone-logo.png";
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   return <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container flex h-16 items-center justify-between px-4">
         {/* Logo */}
         <div className="flex items-center space-x-3">
-          <img 
-            src={tradeStoneLogoCorrect} 
+          <img
+            src={tradestoneLogo}
             alt="TradeStone logo" 
             className="h-10 w-auto"
           />

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,7 +1,7 @@
 import Header from "@/components/Header";
 import HeroSection from "@/components/HeroSection";
 import ContractorDirectory from "@/components/ContractorDirectory";
-import tradeStoneLogoCorrect from "@/assets/tradestone-logo-correct.png";
+import tradestoneLogo from "@/assets/tradestone-logo.png";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -226,8 +226,8 @@ const Index = () => {
             <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
               <div>
                 <div className="flex items-center space-x-2 mb-4">
-                  <img 
-                    src={tradeStoneLogoCorrect} 
+                  <img
+                    src={tradestoneLogo}
                     alt="TradeStone logo" 
                     className="h-8 w-auto"
                   />


### PR DESCRIPTION
## Summary
- import the tradestone logo asset into the header component and reference it in both desktop and mobile views
- import and use the same logo asset for the footer on the index page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d067a4b300832b9b8bfdf72986b345